### PR TITLE
Remove cf-app-utils dependency from newrelic.yml

### DIFF
--- a/services/newrelic/newrelic-ruby.yml
+++ b/services/newrelic/newrelic-ruby.yml
@@ -15,7 +15,7 @@ common: &default_settings
   # You must specify the license key associated with your New Relic
   # account.  This key binds your Agent's data to your account in the
   # New Relic service.
-  license_key: '<%= CF::App::Credentials.find_by_service_name("new-relic")["licenseKey"] %>'
+  license_key: '<%= JSON.parse(ENV["VCAP_SERVICES"])["newrelic"].first["credentials"]["licenseKey"] %>'
 
   # Agent Enabled (Ruby/Rails Only)
   # Use this setting to force the agent to run or not run.


### PR DESCRIPTION
Having cf-app-utils inside the ruby `newrelic.yml` causes an implicit dependency and was a surprise to us. As a template, it should stick to standard library classes.
