### PR TITLE
Documentation page for Gluon CloudLink service

### DIFF
--- a/services/gluoncloudlink.html.md.erb
+++ b/services/gluoncloudlink.html.md.erb
@@ -1,0 +1,62 @@
+---
+title: Gluon CloudLink
+owner: Partners
+---
+
+<strong><%= modified_date %></strong>
+
+Gluon CloudLink is the bridge between your enterprise systems and applications
+running on devices (desktop, laptop, mobile or embedded).
+
+Gluon CloudLink is a Mobile Backend as a Service (MBaaS) providing Mobile Enterprise
+functionality to back-end applications.
+
+Using Gluon CloudLink, your enterprise components can easily integrate with your mobile
+applications. Data that is added or modified on a mobile client can automatically be
+propagated to your enterprise components, using a Gluon CloudLink Connector. Vice versa,
+if the data on your enterprise component changes, you can inform Gluon CloudLink about
+this and this action will propagate the changes to the relevant mobile clients at the
+right moment.
+
+## <a id='managing-services'></a>Managing Services ##
+
+[Managing Service Instances with the CLI](/devguide/services/managing-services.html)
+
+Gluon CloudLink is not a bindable service.
+
+## <a id='managing-sso'></a>Log in to Gluon CloudLink using Single Sign On ##
+
+Log into the [Apps Manager](https://console.run.pivotal.io/). Find your Gluon CloudLink
+service instance on the Space page in which you created it. Click the Manage button to
+log into your Gluon CloudLink account via SSO.
+
+## <a id='create-gcl-app'></a>Creating a Gluon Application ##
+
+From the Gluon CloudLink Dashboard page, you can manage your Gluon CloudLink applications.
+Create a new application by providing a name in the "Add Application" form. A new
+application will be created together with a key and a secret.
+
+## <a id='connect-gcl'></a>Connecting to Gluon CloudLink ##
+
+Use the [Gluon Connect API](http://gluonhq.com/labs/connect/) to connect your client
+application with Gluon CloudLink. The full documentation can be read in the
+[Gluon CloudLink section](http://docs.gluonhq.com/connect/1.1.0/#_gluon_cloudlink) of the
+[Gluon Connect documentation](http://docs.gluonhq.com/connect) website. Step 2.1 can be
+skipped, as you have already performed the actions described in there in the previous
+section of this document.
+
+## <a id='sample-app'></a>Sample Application ##
+
+https://github.com/gluon-samples/pws-gluoncloudlink-whiteboard
+
+## <a id='documentation'></a>Documentation ##
+
+[Gluon CloudLink](http://docs.gluonhq.com/cloudlink)
+
+[Gluon Connect](http://docs.gluonhq.com/connect)
+
+## <a id='support'></a>Support ##
+
+[Contacting Service Providers for Support](../contacting-service-providers-for-support.html)
+
+http://gluonhq.com/support


### PR DESCRIPTION
This is the documentation page for the Gluon CloudLink service in the
Pivotal Web Services marketplace.