### PR TITLE
Fix newrelic service plan

### DIFF
--- a/services/newrelic/index.html.md.erb
+++ b/services/newrelic/index.html.md.erb
@@ -15,7 +15,7 @@ An instance of this service can be provisioned via the CLI with the following
 command:
 
 <pre class="terminal">
-$ cf create-service newrelic standard INSTANCE
+$ cf create-service newrelic lite INSTANCE
 </pre>
 
 Replace `INSTANCE` with a name that is meaningful to you.


### PR DESCRIPTION
`cf marketplace` lists the only available plan level for newrelic (on PWS) as "lite".  Docs should reflect that.