### PR TITLE
Update PWS email proxy functionality documentation

### DIFF
--- a/contacting-service-providers-for-support.html.md.erb
+++ b/contacting-service-providers-for-support.html.md.erb
@@ -12,7 +12,7 @@ When contacting Marketplace service providers for support, you must provide them
 
 ## Space Email Address
 
-Every space has an email alias. This alias is the address used when creating accounts with service providers. When anyone sends an email to this alias, PWS forwards the email to each user in the space with the Space Developer role.
+Every space has an email alias. This alias is the address used when creating accounts with service providers. Service providers wishing to communicate with members of a space where a service instance of theirs is used can do so by contacting `support@run.pivotal.io`. Please provide the content of the communication and the Space GUID or Space Email Address. The PWS Support team will review the message and forward appropriately.
 
 The email address is in the form `space-guid-GUID@email-proxy.run.pivotal.io`, where `GUID` is the guid of the space that contains the service instance. See below for instructions to determine the guid of a space.
 


### PR DESCRIPTION
- Email proxy functionality, used by service providers (vendors) to
communicate with members of a space where their service instance is used,
was removed at beginning of Nov 2020 due to spam/phishing.

Signed-off-by: Larry Hamel <larryh@vmware.com>